### PR TITLE
fix: 修复按钮点击事件被drag区域覆盖导致失效 & 窗口首次打开触发unMaximize 事件

### DIFF
--- a/src/TitleBar.module.less
+++ b/src/TitleBar.module.less
@@ -2,12 +2,17 @@
   cursor: pointer;
   text-align: center;
   position: relative;
-  -webkit-user-select: none;
-  -webkit-app-region: drag;
+  
+  .draggaleArea {
+    -webkit-user-select: none;
+    -webkit-app-region: drag;
+  }
 
   .buttons {
+    -webkit-app-region: no-drag;
     display: flex;
     position: absolute;
+    z-index: 99999;
     right: 0;
     top: 0;
     height: 100%;

--- a/src/TitleBar.tsx
+++ b/src/TitleBar.tsx
@@ -38,15 +38,14 @@ const TitleBar = (props: TitleBarProps) => {
   const iconItemStyle = getIconItemStyle();
   const [isMaximized, setIsMaximized] = useState(false);
 
-  useEffect(() => {
+  const toggleMaximize = () => {
     if (isMaximized) {
-      onMaximize();
-    } else {
       onUnMaximize();
+    } else {
+      onMaximize();
     }
-  }, [
-    isMaximized,
-  ]);
+    setIsMaximized(!isMaximized);
+  };
 
   return (
     <div
@@ -73,7 +72,7 @@ const TitleBar = (props: TitleBarProps) => {
         <div
           className={styles.buttonItem}
           style={iconItemStyle}
-          onClick={() => setIsMaximized(!isMaximized)}
+          onClick={() => toggleMaximize()}
         >
           {isMaximized ? Icons.restore : Icons.maximize}
         </div>

--- a/src/TitleBar.tsx
+++ b/src/TitleBar.tsx
@@ -59,7 +59,9 @@ const TitleBar = (props: TitleBarProps) => {
         backgroundColor: titleBarColor,
       }}
     >
-      {titleText}
+      <div className={styles.draggaleArea}>
+        {titleText}
+      </div>
       <div className={styles.buttons} style={{ fill: iconColor }}>
         <div
           className={styles.buttonItem}


### PR DESCRIPTION
- 修复按钮点击事件被drag区域覆盖导致点击事件失效
- 窗口首次打开触发 unMaximize 事件