### PR TITLE
fix: addon check version & set dark mode flags twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-windows-titlebar",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "windows-style title bar component for Electron",
   "main": "index.js",
   "scripts": {

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -1,35 +1,29 @@
 #include <napi.h>
 #include <dwmapi.h>
+#include <VersionHelpers.h>
 
 #pragma comment (lib, "dwmapi.lib")
 
 /**
- * Windows 11 insider build number: 10.0.22000.194
- * ref: https://chromium.googlesource.com/chromium/src/+/master/base/win/windows_version.h#58
-*/
-static BOOL isWindows11OrLater() {
-  OSVERSIONINFO info;
-  info.dwOSVersionInfoSize = sizeof(info);
-  GetVersionEx(&info);
-
-  if (info.dwMajorVersion > 10) {
-    return true;
-  } else if (info.dwMajorVersion == 10) {
-    return info.dwBuildNumber >= 22000;
-  }
-  return false;
-}
-
-/**
- * DWMWA_USE_IMMERSIVE_DARK_MODE = 20 is supported starting with Windows 11 Build 22000
+ * DWMWA_USE_IMMERSIVE_DARK_MODE = 20 is supported starting with Windows 10 20H2
  * ref: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
 */
 static void changeTheme(Napi::Buffer<void *> wndHandle, bool isDark) {
-  // step 1, get windows build version
-  const int DWMWA_USE_IMMERSIVE_DARK_MODE = isWindows11OrLater() ? 20 : 19;
+  // step 1, check windows version
+  if (!IsWindows10OrGreater()) {
+    return;
+  }
+  const int DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;
+  const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
   // step 2, set window attribute to dark mode
   HWND hwnd = static_cast<HWND>(*reinterpret_cast<void **>(wndHandle.Data()));
   BOOL USE_DARK_MODE = isDark;
+  DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1,
+    &USE_DARK_MODE,
+    sizeof(USE_DARK_MODE)
+  );
   DwmSetWindowAttribute(
     hwnd,
     DWMWA_USE_IMMERSIVE_DARK_MODE,


### PR DESCRIPTION
according to: https://hg.mozilla.org/mozilla-central/file/tip/widget/windows/nsWindow.cpp#l2811
- only run changeTheme while Windows version is 10 or greater
- set both flag 19 and 20 `DwmSetWindowAttribute` for dark mode