### PR TITLE
test: add TitleBar component tests

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,6 @@
+const proxy = new Proxy({}, {
+  get: (target, prop) => prop,
+});
+
+module.exports = proxy;
+module.exports.default = proxy;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
+  },
+};

--- a/src/web/TitleBar.test.tsx
+++ b/src/web/TitleBar.test.tsx
@@ -1,0 +1,71 @@
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import TitleBar from './TitleBar';
+
+describe('TitleBar', () => {
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container) {
+      unmountComponentAtNode(container);
+      container.remove();
+      container = null;
+    }
+  });
+
+  it('renders title text', () => {
+    act(() => {
+      render(<TitleBar titleText="My Title" />, container!);
+    });
+    const wrapper = container!.firstElementChild as HTMLElement;
+    const title = wrapper.firstElementChild as HTMLElement;
+    expect(title.textContent).toBe('My Title');
+  });
+
+  it('triggers callbacks when buttons clicked', () => {
+    const onMinimize = jest.fn();
+    const onMaximize = jest.fn();
+    const onUnMaximize = jest.fn();
+    const onClose = jest.fn();
+
+    act(() => {
+      render(
+        <TitleBar
+          titleText=""
+          onMinimize={onMinimize}
+          onMaximize={onMaximize}
+          onUnMaximize={onUnMaximize}
+          onClose={onClose}
+        />, container!);
+    });
+
+    const wrapper = container!.firstElementChild as HTMLElement;
+    const buttons = wrapper.lastElementChild as HTMLElement;
+    const buttonItems = buttons.children;
+
+    act(() => {
+      (buttonItems[0] as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onMinimize).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      (buttonItems[1] as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onMaximize).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      (buttonItems[1] as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onUnMaximize).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      (buttonItems[2] as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add jest config and style mock to handle TypeScript and CSS modules
- add tests for TitleBar component rendering and button callbacks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc060086688321829ee569bc609e28