### PR TITLE
Expose TitleBar subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.7",
   "description": "windows-style title bar component for Electron",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./TitleBar": "./lib/web/TitleBar.js"
+  },
   "scripts": {
     "dev": "concurrently npm:dev:*",
     "dev:main": "cross-env NODE_ENV=development electron -r ts-node/register/transpile-only ./example/main.ts",
@@ -10,7 +14,7 @@
     "build:web": "tsc && copyup 'src/**/*.less' lib/",
     "build:debug": "node-gyp configure && node-gyp build --debug",
     "build:release": "node-gyp configure && node-gyp build",
-    "build": "node-gyp rebuild",
+    "build": "npm run build:web && node-gyp rebuild",
     "prepublishOnly": "npm run build",
     "clean": "node-gyp clean",
     "test": "jest",
@@ -32,6 +36,13 @@
     "lib/**/*.js",
     "lib/**/*.less"
   ],
+  "typesVersions": {
+    "*": {
+      "TitleBar": [
+        "./lib/web/TitleBar.d.ts"
+      ]
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/electron-modules/electron-windows-titlebar"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "pretty": true,
     "sourceMap": true,
     "baseUrl": ".",
+    "rootDir": "src",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Summary
- add explicit exports/typesVersions entries so the TitleBar component can be imported via the documented subpath
- run the web build before node-gyp to emit the compiled TitleBar assets and copy styles
- set the TypeScript rootDir to keep the web output layout stable

## Testing
- npm run build:web


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693acd3a7aa083218b272b583dce4fd7)